### PR TITLE
minor style fixes for station member list

### DIFF
--- a/css/_station.scss
+++ b/css/_station.scss
@@ -20,6 +20,9 @@ input.action { @include placeholder {
 input.action:focus { @include placeholder { color: transparent; }}
 
 .menu {
+  max-height: 100%;
+  overflow: scroll;
+
   .name,
   .planet {
     display: inline-block;

--- a/js/components/StationComponent.coffee
+++ b/js/components/StationComponent.coffee
@@ -97,8 +97,8 @@ module.exports = recl
             (div {className:"close"}, "✕")
             (h2 {},
               (span {}, "Members")
-              (label {className:"sum"}
-              _.keys(members).length)
+              (label {className:"sum"},
+                _.keys(members).length)
             )
             (for member of members
               (div {key:member},


### PR DESCRIPTION
fixes typo causing station member count to be a `<span/>` instead of a `<label/>,
allows station member list to scroll

Notes:
- this PR branch is based off of `master~1`, since I couldn't get master to run due to `window.tree.util.components.ship` in `MemberComponent`. I thought I had found that object in a branch of `arvo`, but I wasn't able to find it tonight.
- I had to edit all the SCSS bootstrap import paths (`../bootstrap` -> `./bootstrap`) to compile the CSS. Maybe the submodule isn't at the right level by default?
