### PR TITLE
Calculate scroll position from the bottom

### DIFF
--- a/js/components/MessageListComponent.coffee
+++ b/js/components/MessageListComponent.coffee
@@ -99,25 +99,13 @@ module.exports = recl
 
 
   componentWillUpdate: (props, state)->
-    $window = $ window
-    scrollTop = $window.scrollTop()
-    old = {}; old[key] = true for {key} in @state.messages
-    lastSaid = null
-    for message in state.messages
-      nowSaid = [message.ship,message.thought.audience]
-      if not old[message.key]
-        sameAs = _.isEqual lastSaid, nowSaid
-        scrollTop +=  if sameAs
-                        MESSAGE_HEIGHT_SAME
-                      else
-                        MESSAGE_HEIGHT_FIRST
-      lastSaid = nowSaid
-      @setOffset = scrollTop
+    @scrollBottom = $(document).height() - ($(window).scrollTop() + window.innerHeight)
+
 
   componentDidUpdate: (_props, _state)->
-    if @setOffset and @props.chrono isnt "reverse"
-      $(window).scrollTop @setOffset
-      @setOffset = null
+    setOffset = $(document).height() - window.innerHeight - @scrollBottom
+    if @props.chrono isnt "reverse"
+      $(window).scrollTop setOffset
 
     if @focused is false and @last isnt @lastSeen
       _messages = @sortedMessages @state.messages

--- a/js/components/MessageListComponent.coffee
+++ b/js/components/MessageListComponent.coffee
@@ -103,12 +103,17 @@ module.exports = recl
 
 
   componentDidUpdate: (_props, _state)->
+    _messages = @sortedMessages @state.messages
+    _oldMessages = @sortedMessages _state.messages
+    # a message with no key is pending
+    # XX should be message.pending: true
+    appendedToBottom = !_.last(_messages)?.key? or _.last(_messages)?.key > _.last(_oldMessages)?.key
     setOffset = $(document).height() - window.innerHeight - @scrollBottom
     if @props.chrono isnt "reverse"
-      $(window).scrollTop setOffset
+      unless @scrollBottom > 0 and appendedToBottom
+        $(window).scrollTop setOffset
 
     if @focused is false and @last isnt @lastSeen
-      _messages = @sortedMessages @state.messages
       d = _messages.length-_messages.indexOf(@lastSeen)-1
       t = document.title
       if document.title.match(/\([0-9]*\)/)


### PR DESCRIPTION
Previously, when scrolling to the top to fetch messages, the new scroll
position would be calculated based on the number of messages and their
heights.

With this commit, the new scroll position is based on the distance from
the bottom before messages are prepended, since that value should be
equal before and after.

E.g. if the scroll position is 1000px from the bottom before the new
messages are prepended, we make sure the new scroll position is also
1000px from the bottom after they're prepended.

fixes #18 
