### PR TITLE
Calculate speech height based on text width

### DIFF
--- a/css/_grams.scss
+++ b/css/_grams.scss
@@ -79,7 +79,6 @@ div.gram.same:hover div.meta {
   font-size: .9rem;
 
   .speech {
-    white-space: nowrap;
     max-width: 100%;
     overflow-x: scroll;
   }

--- a/css/_grams.scss
+++ b/css/_grams.scss
@@ -71,7 +71,6 @@ div.gram.same:hover div.meta {
 
 .speech {
   margin-left: $grid-gutter-width;
-  white-space: nowrap;
 }
 
 .exp {

--- a/js/components/MessageListComponent.coffee
+++ b/js/components/MessageListComponent.coffee
@@ -98,6 +98,9 @@ module.exports = recl
     @focused = true
     $(window).on 'blur', @_blur
     $(window).on 'focus', @_focus
+    $(window).on 'resize', _.debounce(=>
+      @forceUpdate()
+    , 250)
 
 
   componentWillUpdate: (props, state)->

--- a/js/components/MessageListComponent.coffee
+++ b/js/components/MessageListComponent.coffee
@@ -156,7 +156,6 @@ module.exports = recl
     messageHeights = []
     canvas = document.createElement 'canvas'
     context = canvas.getContext '2d'
-    context.font = FONT_SIZE + 'px bau'
     speechLength = $('.grams').width() - (FONT_SIZE * 1.875)
 
     _messages = messages.map (message,index) =>
@@ -165,6 +164,7 @@ module.exports = recl
       lastSaid = nowSaid
       lineNums = 1
       speechArr = []
+      context.font = FONT_SIZE + 'px bau'
       if message.thought.statement.speech.lin?
         speechArr = message.thought.statement.speech.lin.txt.split(/(\s|-)/)
       else if message.thought.statement.speech.url?
@@ -179,7 +179,7 @@ module.exports = recl
           if word == ' '
             ''
           else if word == '-'
-            _.tail(base.split(/\s|-/).reverse()) + word
+            _.head(base.split(/\s|-/).reverse()) + word
           else
             word
         else

--- a/js/components/MessageListComponent.coffee
+++ b/js/components/MessageListComponent.coffee
@@ -13,10 +13,12 @@ Message         = require './MessageComponent.coffee'
 # Infinite scrolling requires overriding CSS heights. Turn this off to measure
 # the true heights of messages
 # XX rems
+# XX don't hardcode these values
 INFINITE = yes
-MESSAGE_HEIGHT_FIRST = 54
-MESSAGE_HEIGHT_FIRST_MARGIN_TOP = 36
 MESSAGE_HEIGHT_SAME  = 27
+MESSAGE_HEIGHT_FIRST = 56 - MESSAGE_HEIGHT_SAME
+MESSAGE_HEIGHT_FIRST_MARGIN_TOP = 36
+FONT_SIZE = parseInt($('body').css('font-size').match(/(\d*)px/)[1])
 
 module.exports = recl
   displayName: "Messages"
@@ -149,18 +151,44 @@ module.exports = recl
     lastSaid = null
 
     messageHeights = []
+    canvas = document.createElement 'canvas'
+    context = canvas.getContext '2d'
+    context.font = FONT_SIZE + 'px bau'
+    speechLength = $('.grams').width() - (FONT_SIZE * 1.875)
 
     _messages = messages.map (message,index) =>
       nowSaid = [message.ship,_.keys(message.thought.audience)]
       sameAs = _.isEqual lastSaid, nowSaid
       lastSaid = nowSaid
+      lineNums = 1
+      speechArr = []
+      if message.thought.statement.speech.lin?
+        speechArr = message.thought.statement.speech.lin.txt.split(/(\s|-)/)
+      else if message.thought.statement.speech.url?
+        speechArr = message.thought.statement.speech.url.txt.split(/(\s|-)/)
+      else if message.thought.statement.speech.fat?
+        context.font = (FONT_SIZE * 0.9) + 'px scp'
+        speechArr = message.thought.statement.speech.fat.taf.exp.txt.split(/(\s|-)/)
+
+      _.reduce(_.tail(speechArr), (base, word) ->
+        if context.measureText(base + word).width > speechLength
+          lineNums += 1
+          if word == ' '
+            ''
+          else if word == '-'
+            _.tail(base.split(/\s|-/).reverse()) + word
+          else
+            word
+        else
+          return base + word
+      , _.head(speechArr))
 
       if INFINITE
         if sameAs
-          height = MESSAGE_HEIGHT_SAME
+          height = MESSAGE_HEIGHT_SAME * lineNums
           marginTop = 0
         else
-          height = MESSAGE_HEIGHT_FIRST
+          height = MESSAGE_HEIGHT_FIRST + (MESSAGE_HEIGHT_SAME * lineNums)
           marginTop = MESSAGE_HEIGHT_FIRST_MARGIN_TOP
       else
         height = null


### PR DESCRIPTION
Fixes urbit/talk#17

So to make a long story short, the react-infinite-any-height repo is just a small wrapper around react-infinite that uses a strategy similar to what I described in #17. That strategy doesn't really work for :talk due to the nature of scrolling bottom to top.

This PR uses canvas to calculate the length of text, which is actually pretty accurate and doesn't require any DOM manipulation (only downside is you have to break the text manually). 

Tested this on a number of viewport sizes / message text, but could always use more testing.

At some point might want to move these calculations outside of `render()` and put them in the `state` to avoid expensive re-renders and having to use `forceUpdate`.
