### PR TITLE
Tab autocompletion for ~ship names.

### DIFF
--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -157,6 +157,25 @@ module.exports = recl
           $('#offline').addClass('error').one 'transitionend',
             -> $('#offline').removeClass 'error'
       return false
+    if e.keyCode is 9
+      e.preventDefault()
+      txt = @$message.text()
+      tindex = txt.lastIndexOf("~")
+      if tindex is -1
+        return false
+      ptxt = txt.substr(tindex+1)
+      if ptxt.length < 13 and ptxt.match('^[a-z]{1,6}([\\-\\^_][a-z]{0,5})?$')?
+        fname = null
+        for own name, obj of @state.members[@state.ludi[0]]
+          if name.indexOf(ptxt) is 1
+            fname = name.substr(1)
+            break
+        if fname?
+          if fname.length > 13
+            fname = fname.substr(0, 6) + '_' + fname.substr(-6)
+          @$message.append(fname.substr(ptxt.length))
+          @cursorAtEnd()
+      return false
     @onInput()
     @set()
 

--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -164,11 +164,11 @@ module.exports = recl
       if tindex is -1
         return false
       ptxt = txt.substr(tindex+1)
-      if ptxt.length < 13 and ptxt.match('^[a-z]{1,6}([\\-\\^_][a-z]{0,5})?$')?
+      if ptxt.length < 13 and ptxt.match('^[a-z]{0,6}([\\-\\^_][a-z]{0,5})?$')?
         fname = null
-        for own name, obj of @state.members[@state.ludi[0]]
-          if name.indexOf(ptxt) is 1
-            fname = name.substr(1)
+        for msg in MessageStore.getAll() by -1
+          if msg.ship.indexOf(ptxt) is 0
+            fname = msg.ship
             break
         if fname?
           if fname.length > 13

--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -177,12 +177,9 @@ module.exports = recl
       if ptxt.length < 13 and ptxt.match('^[a-z]{0,6}([\\-\\^_][a-z]{0,5})?$')?
         @tabList = []
         for msg in MessageStore.getAll() by -1
-          if msg.ship.indexOf(ptxt) is 0 and @tabList.indexOf(msg.ship) == -1
-            @tabList.push(msg.ship)
+          @_processAutoCompleteName(ptxt, msg.ship)
         for own name, obj of @state.members[@state.ludi[0]]
-          trimname = name.substr(1)
-          if name.indexOf(ptxt) is 1 and @tabList.indexOf(trimname) == -1
-            @tabList.push(trimname)
+          @_processAutoCompleteName(ptxt, name.substr(1))
     if @tabList? and @tabList.length > 0
       if @tabIndex?
         if event.shiftKey
@@ -193,12 +190,16 @@ module.exports = recl
       else
         @tabIndex = 0
       name = @tabList[@tabIndex]
-      if name.length > 27
-        name = name.substr(0, 6) + '_' + name.substr(-6)
-      else if name.length > 13
-        name = name.substr(-13).replace('-', '^')
       @$message.text(@$message.text().substr(0, tindex+1) + name)
       @cursorAtEnd()
+  
+  _processAutoCompleteName: (ptxt, name) ->
+    if name.length is 27
+      name = name.substr(-13).replace('-', '^')
+    else if name.length is 56
+      name = name.substr(0, 6) + '_' + name.substr(-6)
+    if name.indexOf(ptxt) is 0 and @tabList.indexOf(name) == -1
+      @tabList.push(name)
   
   onInput: (e) ->
     text   = @$message.text()

--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -159,26 +159,47 @@ module.exports = recl
       return false
     if e.keyCode is 9
       e.preventDefault()
-      txt = @$message.text()
-      tindex = txt.lastIndexOf("~")
-      if tindex is -1
-        return false
-      ptxt = txt.substr(tindex+1)
-      if ptxt.length < 13 and ptxt.match('^[a-z]{0,6}([\\-\\^_][a-z]{0,5})?$')?
-        fname = null
-        for msg in MessageStore.getAll() by -1
-          if msg.ship.indexOf(ptxt) is 0
-            fname = msg.ship
-            break
-        if fname?
-          if fname.length > 13
-            fname = fname.substr(0, 6) + '_' + fname.substr(-6)
-          @$message.append(fname.substr(ptxt.length))
-          @cursorAtEnd()
+      @_autoComplete()
       return false
+    else if @tabList? and e.keyCode isnt 16
+      @tabList = null
+      @tabIndex = null
     @onInput()
     @set()
-
+  
+  _autoComplete: ->
+    txt = @$message.text()
+    tindex = txt.lastIndexOf('~')
+    if tindex is -1
+      return
+    if not @tabList?
+      ptxt = txt.substr(tindex+1)
+      if ptxt.length < 13 and ptxt.match('^[a-z]{0,6}([\\-\\^_][a-z]{0,5})?$')?
+        @tabList = []
+        for msg in MessageStore.getAll() by -1
+          if msg.ship.indexOf(ptxt) is 0 and @tabList.indexOf(msg.ship) == -1
+            @tabList.push(msg.ship)
+        for own name, obj of @state.members[@state.ludi[0]]
+          trimname = name.substr(1)
+          if name.indexOf(ptxt) is 1 and @tabList.indexOf(trimname) == -1
+            @tabList.push(trimname)
+    if @tabList? and @tabList.length > 0
+      if @tabIndex?
+        if event.shiftKey
+          @tabIndex--
+        else
+          @tabIndex++
+        @tabIndex = (@tabIndex % @tabList.length + @tabList.length) % @tabList.length
+      else
+        @tabIndex = 0
+      name = @tabList[@tabIndex]
+      if name.length > 27
+        name = name.substr(0, 6) + '_' + name.substr(-6)
+      else if name.length > 13
+        name = name.substr(-13).replace('-', '^')
+      @$message.text(@$message.text().substr(0, tindex+1) + name)
+      @cursorAtEnd()
+  
   onInput: (e) ->
     text   = @$message.text()
     length = text.length


### PR DESCRIPTION
Implements on-tab autocompletion of ship names (`~` followed by zero or more characters in a valid short ship-name pattern). Press tab again to cycle forward through possible matches. Shift-tab cycles backwards. Matches are ordered "most recently spoke" first.

This is accomplished by, on first tab-press, going over all recent messages to find matching ship names, followed by all station members, compressing moon and comet names into their short versions as needed. This seems performant enough to deliver instantaneous results even for the busiest stations, though I haven't been able to test this on a lower-end machine. The list of matches is discarded when any key other than tab is pressed.

Do note that this only autocompletes text from the last `~` in your message up to the end of it, _if_ it can be a valid ship name. So:
`hello ~tor` autocompletes,
`hello ~tor!` doesn't.
`hello ~` autocompletes, matching _all_ ships.
This should correspond to the expected behavior.

Ideally you may want this implemented in :talk (so the CLI version can also enjoy tab completion), and have this web client ask it for autocomplete matches.

I didn't encounter any code comments in existing code, so I refrained from adding those. Hopefully my additions are straight-forward enough, but I'll gladly add some comments if needed.

Let me know if this is up to standard, any and all feedback is appreciated!
