### PR TITLE
Audience input enhancements and leading ~ display

### DIFF
--- a/js/components/MemberComponent.coffee
+++ b/js/components/MemberComponent.coffee
@@ -7,7 +7,6 @@ module.exports = recl
   displayName:"Member"
   render: ->
     ship = @props.ship
-    if ship[0] is "~" then @props.ship = ship.slice(1)
 
     k = "ship"
     k+= " #{@props.presence}" if @props.presence

--- a/js/components/MessageComponent.coffee
+++ b/js/components/MessageComponent.coffee
@@ -73,7 +73,7 @@ module.exports = recl
 
     name = if @props.name then @props.name else ""
     aude = _.keys thought.audience
-    audi = util.clipAudi(aude).map (_audi) -> (div {key:_audi}, _audi.slice(1))
+    audi = util.clipAudi(aude).map (_audi) -> (div {key:_audi}, _audi)
 
     mainStation = util.mainStationPath(window.urb.user)
     type = if mainStation in aude then 'private' else 'public'

--- a/js/components/StationComponent.coffee
+++ b/js/components/StationComponent.coffee
@@ -113,7 +113,7 @@ module.exports = recl
             (div {
               className:(if @state.open is source then "selected" else "")
               onClick:@_openStation
-              "data-station":source}, source.slice(1))
+              "data-station":source}, source)
             (div {
               className:"close"
               onClick:@_remove

--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -339,7 +339,8 @@ module.exports = recl
     audi = if @state.audi.length is 0 then @state.ludi else @state.audi
     audi = util.clipAudi audi
     for k,v of audi
-      audi[k] = v.slice(1)
+      if audi[k].indexOf('~~') is 0
+        audi[k] = v.slice(1)
 
     div {className:'writing',key:'writing'},
       (React.createElement Audience, {

--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -76,14 +76,18 @@ Audience = recl
 
   _autoCompleteAudience: ->
     txt = $('#audience .input').text().trim()
-    if not (txt[0] is '~')
-      txt = '~'+txt
     if not @tabAudList?
       @tabAudList = []
-      for g,stations of StationStore.getGlyphs()
-        for aud in stations
-          if aud[0].indexOf(txt) is 0
-            @tabAudList.push(aud[0])
+      if txt.length is 1 and StationStore.getGlyphs()[txt[0]]
+        for s in @_getGlyphExpansions(txt[0])
+          @tabAudList.push(s[0])
+      else
+        if not (txt[0] is '~')
+          txt = '~'+txt
+        for g,stations of StationStore.getGlyphs()
+          for aud in stations
+            if aud[0].indexOf(txt) is 0 and @tabAudList.indexOf(aud[0]) < 0
+              @tabAudList.push(aud[0])
     if @tabAudList? and @tabAudList.length > 0
       if @tabAudIndex?
         if event.shiftKey
@@ -93,7 +97,12 @@ Audience = recl
         @tabAudIndex = (@tabAudIndex % @tabAudList.length + @tabAudList.length) % @tabAudList.length
       else
         @tabAudIndex = 0
-      $('#audience .input').text(@tabAudList[@tabAudIndex])
+      StationActions.setAudience(@tabAudList[@tabAudIndex].split /\ +/)
+
+  _getGlyphExpansions: (g) ->
+    glyphs = StationStore.getGlyphs()
+    if glyphs[g]
+      return glyphs[g]
 
   render: ->
     div {className:'audience',id:'audience',key:'audience'}, (div {
@@ -270,20 +279,9 @@ module.exports = recl
     v = v.trim()
     if v.length is 0 
       return true
-    if v.length is 1
-      v = @_expandAudiGlyph(v)
-    if not (v[0] is "~")
-      v = "~"+v
-    $('#audience .input').text(v) # Bugged, doesn't include leading ~.
-    if v.length < 6 # ~zod/a is shortest
+    if v.length < 5 # zod/a is shortest
       return false
     _.all (v.split /\ +/), @_validateAudiPart
-
-  _expandAudiGlyph: (g) ->
-    glyphs = StationStore.getGlyphs()
-    if glyphs[g]
-      return glyphs[g][0][0]
-    return g
 
   _setAudi: ->
     valid = @_validateAudi()

--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -238,9 +238,20 @@ module.exports = recl
     v = v.trim()
     if v.length is 0 
       return true
-    if v.length < 5 # zod/a is shortest
+    if v.length is 1
+      v = @_expandAudiGlyph(v)
+    if not (v[0] is "~")
+      v = "~"+v
+    $('#audience .input').text(v) # Bugged, doesn't include leading ~.
+    if v.length < 6 # ~zod/a is shortest
       return false
     _.all (v.split /\ +/), @_validateAudiPart
+
+  _expandAudiGlyph: (g) ->
+    glyphs = StationStore.getGlyphs()
+    if glyphs[g]
+      return glyphs[g][0][0]
+    return g
 
   _setAudi: ->
     valid = @_validateAudi()

--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -63,6 +63,38 @@ Audience = recl
       if @props.validate()
         setTimeout (-> $('.writing').focus()),0
         return false
+    if e.keyCode is 9
+      # Ideally we'd want to do this, but we can't because of scope:
+      # if (not @tabAudList?) and _validateAudi()
+      #  return true
+      e.preventDefault()
+      @_autoCompleteAudience()
+      return false
+    else if @tabAudList? and e.keyCode isnt 16
+      @tabAudList = null
+      @tabAudIndex = null
+
+  _autoCompleteAudience: ->
+    txt = $('#audience .input').text().trim()
+    if not (txt[0] is '~')
+      txt = '~'+txt
+    if not @tabAudList?
+      @tabAudList = []
+      for g,stations of StationStore.getGlyphs()
+        for aud in stations
+          if aud[0].indexOf(txt) is 0
+            @tabAudList.push(aud[0])
+    if @tabAudList? and @tabAudList.length > 0
+      if @tabAudIndex?
+        if event.shiftKey
+          @tabAudIndex--
+        else
+          @tabAudIndex++
+        @tabAudIndex = (@tabAudIndex % @tabAudList.length + @tabAudList.length) % @tabAudList.length
+      else
+        @tabAudIndex = 0
+      $('#audience .input').text(@tabAudList[@tabAudIndex])
+
   render: ->
     div {className:'audience',id:'audience',key:'audience'}, (div {
           className:"input valid-#{@props.valid}"

--- a/js/stores/StationStore.coffee
+++ b/js/stores/StationStore.coffee
@@ -76,6 +76,8 @@ StationStore = _.merge new EventEmitter,{
       for aud in auds
         _shpylg[aud.join " "] = char
 
+  getGlyphs: -> _glyphs
+
   getStations: -> _stations
 
   setStation: (station) -> _station = station


### PR DESCRIPTION
As requested in PR #24:

Tab autocompletion for audience station names. Currently pulls a station list from StationStore, which means the best we can get is all stations that have glyphs bound to them. Not exactly what was requested, but should satisfy a fair share of use cases.

Also expands glyphs to the full station name when the audience gets validated, defaulting to whatever station it finds first in case multiple stations are bound on the same glyph.

Note: Line 277 of `WritingComponent.coffee` seems a bit bugged. It inserts the station but omits the leading `~` for some reason. No idea what's up with that. 
