### PR TITLE
Less greedy message fetching on load

### DIFF
--- a/js/actions/MessageActions.coffee
+++ b/js/actions/MessageActions.coffee
@@ -15,7 +15,7 @@ Persistence = _persistence MessageActions: module.exports =
     Dispatcher.handleServerAction {messages,last,get,type:"messages-load"}
 
   listenStation: (station,date) ->
-    if not date then date = window.urb.util.toDate (
+    if not date then date = (
       now = new Date()
       # now.setMinutes 0
       now.setSeconds 0

--- a/js/actions/MessageActions.coffee
+++ b/js/actions/MessageActions.coffee
@@ -20,7 +20,7 @@ Persistence = _persistence MessageActions: module.exports =
       # now.setMinutes 0
       now.setSeconds 0
       now.setMilliseconds 0
-      new Date (now - 24*3600*1000)
+      new Date (now - 6*3600*1000)
     )
     Dispatcher.handleViewAction type:"messages-fetch"
     Persistence.listenStation station,date

--- a/js/components/MessageListComponent.coffee
+++ b/js/components/MessageListComponent.coffee
@@ -30,7 +30,7 @@ module.exports = recl
 
   stateFromStore: -> {
     messages:MessageStore.getAll()
-    last:MessageStore.getLast()
+    oldest:MessageStore.getOldest()
     fetching:MessageStore.getFetching()
     listening:MessageStore.getListening()
     station:StationStore.getStation()
@@ -61,15 +61,16 @@ module.exports = recl
       else $(window).scrollTop() < @paddingTop
 
   checkMore: ->
+    @state.oldest = MessageStore.getOldest()
     if @atScrollEdge() &&
         @state.fetching is false &&
-        this.state.last &&
-        this.state.last > 0
-      end = @state.last-@pageSize
+        this.state.oldest &&
+        this.state.oldest > 0
+      end = @state.oldest-@pageSize
       end = 0 if end < 0
       @lastLength = @length
       if end >= 0
-        MessageActions.getMore @state.station,(@state.last+1),end
+        MessageActions.getMore @state.station,(@state.oldest+1),end
 
   setAudience: ->
     return if @state.typing or not @last

--- a/js/persistence/MessagePersistence.coffee
+++ b/js/persistence/MessagePersistence.coffee
@@ -6,7 +6,9 @@ send = (data,cb)-> window.urb.send data, {mark:"hall-action"}, cb
 module.exports = ({MessageActions}) ->
   listenStation: (station,since) ->
     $this = this
-    path = (util.talkPath 'circle', station, 'grams', since)
+    begin = since;
+    begin = window.urb.util.toDate(since) if (typeof since == "object")
+    path = (util.talkPath 'circle', station, 'grams', begin)
     window.urb.bind path, (err,res) ->
         if err or not res.data
           console.log path, 'err!'
@@ -17,10 +19,14 @@ module.exports = ({MessageActions}) ->
         if res.data.ok is true
           MessageActions.listeningStation station
         if res.data?.circle?.nes # prize
-          res.data.circle.nes.map (env) ->
-            env.gam.heard = true
-            env
-          MessageActions.loadMessages res.data.circle.nes
+          if (res.data.circle.nes.length == 0) and (typeof since == "object")
+            console.log 'trying for older than ' + begin
+            $this.listenStation(station, new Date(since - 6*3600*1000))
+          else
+            res.data.circle.nes.map (env) ->
+              env.gam.heard = true
+              env
+            MessageActions.loadMessages res.data.circle.nes
         if res.data?.circle?.gram # rumor (new msg)
           res.data.circle.gram.gam.heard = true
           MessageActions.loadMessages [res.data.circle.gram]

--- a/js/persistence/MessagePersistence.coffee
+++ b/js/persistence/MessagePersistence.coffee
@@ -6,8 +6,7 @@ send = (data,cb)-> window.urb.send data, {mark:"hall-action"}, cb
 module.exports = ({MessageActions}) ->
   listenStation: (station,since) ->
     $this = this
-    begin = since;
-    begin = window.urb.util.toDate(since) if (typeof since == "object")
+    begin = window.urb.util.toDate(since)
     path = (util.talkPath 'circle', station, 'grams', begin)
     window.urb.bind path, (err,res) ->
         if err or not res.data
@@ -19,7 +18,7 @@ module.exports = ({MessageActions}) ->
         if res.data.ok is true
           MessageActions.listeningStation station
         if res.data?.circle?.nes # prize
-          if (res.data.circle.nes.length == 0) and (typeof since == "object")
+          if (res.data.circle.nes.length == 0)
             console.log 'trying for older than ' + begin
             $this.listenStation(station, new Date(since - 6*3600*1000))
           else

--- a/js/stores/MessageStore.coffee
+++ b/js/stores/MessageStore.coffee
@@ -6,7 +6,7 @@ MessageDispatcher = require '../dispatcher/Dispatcher.coffee'
 
 _messages = {}
 _fetching = false
-_last = null
+_oldest = null
 _station  = null
 _filter = null
 _listening = []
@@ -58,15 +58,15 @@ MessageStore = _.merge new EventEmitter,{
   sendMessage: (message) -> _messages[message.uid] = message
 
   loadMessages: (messages,get) ->
-    max = 0
+    min = _oldest
     for v in messages
       v.gam.key = v.num
-      max = v.num if v.num > max
+      min = v.num if v.num < min or min is null
       v = v.gam or v # open envelope
       serial = v.uid
       # always overwrite with new
       _messages[serial] = v
-    _last = max if max < _last or _last is null or get is true
+    _oldest = min if min < _oldest or _oldest is null or get is true
     _fetching = false
 
   getAll: ->
@@ -81,7 +81,7 @@ MessageStore = _.merge new EventEmitter,{
 
   setFetching: (state) -> _fetching = state
 
-  getLast: -> _last
+  getOldest: -> _oldest
 }
 
 MessageStore.setMaxListeners 100


### PR DESCRIPTION
To prevent a dig: over in eyre, request messages from the last 6 hours on load, as opposed to the last 24 hours.  
If this results in no messages being retrieved, it tries to get messages from the last 12 hours, then 18, etc.

Also contains a fix for scrollback loading which wasn't working reliably.