### PR TITLE
Make stream possible again

### DIFF
--- a/js/components/WritingComponent.coffee
+++ b/js/components/WritingComponent.coffee
@@ -176,7 +176,7 @@ module.exports = recl
       return
 
     if @props['audience-lock']?
-      audi = _.union audi, ["~#{window.urb.ship}/#{@props.station}"]
+      audi = ["~#{window.urb.ship}/#{@props.station}"]
 
     audi = @addCC audi
 

--- a/js/persistence/MessagePersistence.coffee
+++ b/js/persistence/MessagePersistence.coffee
@@ -1,7 +1,6 @@
 util = require '../util.coffee'
 
 window.urb.appl = "hall"
-send = (data,cb)-> window.urb.send data, {mark:"hall-action"}, cb
 
 module.exports = ({MessageActions}) ->
   listenStation: (station,since) ->
@@ -51,7 +50,17 @@ module.exports = ({MessageActions}) ->
           console.log res
 
   sendMessage: (message,cb) ->
-    send {convey: [message]}, (err,res) ->
-      console.log 'sent'
-      console.log arguments
-      cb(err,res) if cb
+    if window.urb.user == window.urb.ship
+      window.urb.send {convey: [message]},
+        {mark: "hall-action"},
+        (err,res) ->
+          console.log 'sent local'
+          console.log arguments
+          cb(err,res) if cb
+    else
+      window.urb.send {publish: [message]},
+        {mark: "hall-command"},
+        (err,res) ->
+          console.log 'sent remote'
+          console.log arguments
+          cb(err,res) if cb


### PR DESCRIPTION
When the logged in ship and host don't match up, we send a command rather than an action.

Also includes a small fix for weird audiences being set if some audience got loaded from cookies/localstorage/whatever's used.

Depends on urbit/arvo#507